### PR TITLE
Add restricted Codex change request command with GitHub issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project is a customizable Discord bot that integrates AI functionalities us
 - AI-based responses using OpenAI.
 - Text-to-speech using Piper TTS.
 - Modular design to easily add more features through cogs.
+- New restricted command for AI change requests: `$codexchange <request>` creates a GitHub issue for your automation workflow and pings the reviewer you configure.
 
 ## Installation
 
@@ -36,7 +37,12 @@ This project is a customizable Discord bot that integrates AI functionalities us
     {
         "client_token": "your-discord-bot-token",
         "command_prefix": "$",
-        "OPEN_AI_KEY": "your-openai-api-key"
+        "OPEN_AI_KEY": "your-openai-api-key",
+        "GITHUB_TOKEN": "github-personal-access-token",
+        "GITHUB_REPO": "owner/repository",
+        "GITHUB_CHANGE_REQUEST_LABELS": ["ai-change"],
+        "CODEX_ALLOWED_USERS": [123456789012345678],
+        "CODEX_REVIEWER_DISCORD_ID": 123456789012345678
     }
     ```
 
@@ -56,6 +62,11 @@ This project is a customizable Discord bot that integrates AI functionalities us
  ```
  $help
  ```
+- Restricted codex workflow command:
+ ```
+ $codexchange Update the About page copy and add a CTA button
+ ```
+ This creates a labeled GitHub issue for your AI automation pipeline and mentions the configured reviewer.
 
 ## File Structure
 - `main.py`: The main script that runs the bot.
@@ -63,4 +74,3 @@ This project is a customizable Discord bot that integrates AI functionalities us
 - `requirements.txt`: Contains the Python dependencies.
 - `cogs/`: Contains modular commands and features for the bot, such as the AI capabilities in `open_ai/cog.py`.
 - `tts_voices/`: Contains the Piper TTS model files (`model.onnx` and `model.onnx.json`).
-

--- a/cogs/open_ai/cog.py
+++ b/cogs/open_ai/cog.py
@@ -1,11 +1,13 @@
+import asyncio
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+
 import discord
 from discord.ext import commands
-from discord.utils import get
-import logging
 from openai import OpenAI
-import os
-import asyncio
-
 
 
 class Roast(commands.Cog):
@@ -17,44 +19,77 @@ class Roast(commands.Cog):
         api_key = self.config["OPEN_AI_KEY"]
         self.aiclient = OpenAI(api_key=api_key)
 
-    @commands.command(
-            help="Debugs any given code"
-    )
+    def _github_headers(self):
+        token = self.config.get("GITHUB_TOKEN", "")
+        return {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        }
+
+    def _create_change_request_issue(self, request: str, requested_by: discord.Member):
+        repo = self.config.get("GITHUB_REPO", "")
+        endpoint = f"https://api.github.com/repos/{repo}/issues"
+
+        issue_payload = {
+            "title": f"AI Change Request: {request[:72]}",
+            "body": (
+                "## Requested Change\n"
+                f"{request}\n\n"
+                "## Requested By\n"
+                f"- Discord user: {requested_by} (`{requested_by.id}`)\n\n"
+                "## Notes\n"
+                "- This issue was created by the Discord bot.\n"
+                "- Run the AI automation workflow and open a PR for review."
+            ),
+            "labels": self.config.get("GITHUB_CHANGE_REQUEST_LABELS", ["ai-change"]),
+        }
+
+        req = urllib.request.Request(
+            endpoint,
+            data=json.dumps(issue_payload).encode("utf-8"),
+            headers=self._github_headers(),
+            method="POST",
+        )
+
+        with urllib.request.urlopen(req, timeout=20) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    @commands.command(help="Debugs any given code")
     async def debug(self, ctx: commands.Context, *, arg: str):
-            # Get user input
-            request = f"{arg}"
-            try:
-                # OPENAI API call with user's input
-                def generate(prompt):
-                    response = self.aiclient.chat.completions.create(
-                        model="gpt-4o",
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": "You will be provided with a piece of code, and your task is to find and fix bugs in it",
-                            },
-                            {"role": "user", "content": prompt},
-                        ],
-                        max_tokens=1024,
-                    )
-                    return response.choices[0].message.content
+        # Get user input
+        request = f"{arg}"
+        try:
+            # OPENAI API call with user's input
+            def generate(prompt):
+                response = self.aiclient.chat.completions.create(
+                    model="gpt-4o",
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": "You will be provided with a piece of code, and your task is to find and fix bugs in it",
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    max_tokens=1024,
+                )
+                return response.choices[0].message.content
 
-                response = generate(request)
-                # Split the response if it's longer than 2000 characters
-                if len(response) > 2000:
-                    parts = [response[i:i+2000] for i in range(0, len(response), 2000)]
-                    for part in parts:
-                        await ctx.send(part)
-                else:
-                    await ctx.send(response)
+            response = generate(request)
+            # Split the response if it's longer than 2000 characters
+            if len(response) > 2000:
+                parts = [response[i : i + 2000] for i in range(0, len(response), 2000)]
+                for part in parts:
+                    await ctx.send(part)
+            else:
+                await ctx.send(response)
 
-            except Exception as e:
-                logging.error(e)
-                print(e)
+        except Exception as e:
+            logging.error(e)
+            print(e)
 
-    @commands.command(
-            help="Ask the bot any question"
-    )
+    @commands.command(help="Ask the bot any question")
     async def ask(self, ctx: commands.Context, *, arg: str):
         request = f"{arg}"
 
@@ -72,20 +107,17 @@ class Roast(commands.Cog):
 
             # Split the response if it's longer than 2000 characters
             if len(response) > 2000:
-                parts = [response[i:i+2000] for i in range(0, len(response), 2000)]
+                parts = [response[i : i + 2000] for i in range(0, len(response), 2000)]
                 for part in parts:
                     await ctx.send(part)
             else:
                 await ctx.send(response)
 
-
         except Exception as e:
             logging.error(e)
             print(e)
 
-    @commands.command(
-            help="Ask the bot to generate a roast"
-    )
+    @commands.command(help="Ask the bot to generate a roast")
     async def roast(self, ctx: commands.Context, *, arg: str):
         request = f"Roast {arg}"
 
@@ -112,21 +144,21 @@ class Roast(commands.Cog):
             logging.error(e)
             print(e)
 
-    @commands.command(
-            help="Joins the voice chat to deliver generated roast"
-    )
+    @commands.command(help="Joins the voice chat to deliver generated roast")
     async def vcroast(self, ctx: commands.Context, *, arg: str):
         request = f"Roast {arg}"
         logging.info(request)
 
         def text_to_mp3(text: str):
-           
+
             model_file = "tts_voices/model.onnx"
             model_config = "tts_voices/model.onnx.json"
 
             # Check if both files exist
             if os.path.exists(model_file) and os.path.exists(model_config):
-                os.system(f"echo \"{text}\" | piper --model {model_file} --output_file speech.wav")
+                os.system(
+                    f"echo \"{text}\" | piper --model {model_file} --output_file speech.wav"
+                )
                 logging.info("Speech generation started.")
             else:
                 logging.error(f"Required files not found: {model_file} or {model_config}")
@@ -163,6 +195,38 @@ class Roast(commands.Cog):
             await vc.disconnect()
             os.remove("speech.wav")
 
+    @commands.command(
+        name="codexchange",
+        help="Create a GitHub change request for AI/Codex automation (restricted users only)",
+    )
+    async def codex_change_request(self, ctx: commands.Context, *, arg: str):
+        allowed_users = {int(uid) for uid in self.config.get("CODEX_ALLOWED_USERS", [])}
+        if ctx.author.id not in allowed_users:
+            await ctx.send("You are not allowed to use this command.")
+            return
+
+        if not self.config.get("GITHUB_REPO") or not self.config.get("GITHUB_TOKEN"):
+            await ctx.send("Bot is missing GitHub configuration for change requests.")
+            return
+
+        try:
+            issue = self._create_change_request_issue(arg, ctx.author)
+            reviewer_id = self.config.get("CODEX_REVIEWER_DISCORD_ID")
+            reviewer_mention = f"<@{reviewer_id}> " if reviewer_id else ""
+            await ctx.send(
+                f"{reviewer_mention}New Codex change request created: {issue['html_url']}\n"
+                "I will ping you again when a PR is ready to review."
+            )
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8", errors="replace")
+            logging.error("GitHub issue creation failed: %s", error_body)
+            await ctx.send(
+                "Failed to create the GitHub change request. Check bot logs for details."
+            )
+        except Exception as e:
+            logging.error("Unexpected error creating change request: %s", e)
+            await ctx.send("Failed to create the GitHub change request.")
+
 
 async def setup(client: commands.Bot):
-        await client.add_cog(Roast(client))
+    await client.add_cog(Roast(client))

--- a/sample.config.json
+++ b/sample.config.json
@@ -1,5 +1,14 @@
 {
     "client_token": "",
     "command_prefix": "$",
-    "OPEN_AI_KEY" : ""
+    "OPEN_AI_KEY": "",
+    "GITHUB_TOKEN": "",
+    "GITHUB_REPO": "owner/repo",
+    "GITHUB_CHANGE_REQUEST_LABELS": [
+        "ai-change"
+    ],
+    "CODEX_ALLOWED_USERS": [
+        123456789012345678
+    ],
+    "CODEX_REVIEWER_DISCORD_ID": 123456789012345678
 }


### PR DESCRIPTION
### Motivation
- Provide a safe, auditable way for authorized Discord users to request AI/Codex-driven changes without letting the bot push to the main branch.
- Create a labeled GitHub change-request issue for downstream automation and notify the configured reviewer so a human can open/merge the PR.

### Description
- Added GitHub helpers to `cogs/open_ai/cog.py`: `_github_headers` and `_create_change_request_issue` to assemble and POST a labeled issue to the configured repository.
- Implemented a new restricted Discord command `codexchange` in `cogs/open_ai/cog.py` that validates allowed user IDs from config, checks required GitHub settings, creates the change-request issue, and mentions the configured reviewer with the issue URL while handling API errors.
- Added configuration fields to `sample.config.json`: `GITHUB_TOKEN`, `GITHUB_REPO`, `GITHUB_CHANGE_REQUEST_LABELS`, `CODEX_ALLOWED_USERS`, and `CODEX_REVIEWER_DISCORD_ID`.
- Updated `README.md` to document the new `codexchange` command and the new configuration options and example usage.

### Testing
- Ran `python -m compileall main.py cogs/open_ai/cog.py` which completed successfully.
- Ran `python -m compileall cogs/open_ai/cog.py` which completed successfully; no automated runtime tests were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c2b25da8832b9a446c95ec70336e)