### PR TITLE
Modernize startup/config and harden OpenAI cog voice join/playback

### DIFF
--- a/cogs/open_ai/cog.py
+++ b/cogs/open_ai/cog.py
@@ -1,168 +1,201 @@
+import asyncio
+import logging
+import subprocess
+from pathlib import Path
+
 import discord
 from discord.ext import commands
-from discord.utils import get
-import logging
 from openai import OpenAI
-import os
-import asyncio
 
+
+MAX_DISCORD_MESSAGE_LEN = 2000
 
 
 class Roast(commands.Cog):
-    def __init__(self, client):
+    def __init__(self, client: commands.Bot):
         self.client = client
         self.config = client.config
+        self.aiclient = OpenAI(api_key=self.config["OPEN_AI_KEY"])
 
-        # Import OPENAI API key from config file
-        api_key = self.config["OPEN_AI_KEY"]
-        self.aiclient = OpenAI(api_key=api_key)
+    async def _send_long_message(self, ctx: commands.Context, message: str) -> None:
+        if not message:
+            await ctx.send("I got an empty response. Please try again.")
+            return
 
-    @commands.command(
-            help="Debugs any given code"
-    )
-    async def debug(self, ctx: commands.Context, *, arg: str):
-            # Get user input
-            request = f"{arg}"
-            try:
-                # OPENAI API call with user's input
-                def generate(prompt):
-                    response = self.aiclient.chat.completions.create(
-                        model="gpt-4o",
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": "You will be provided with a piece of code, and your task is to find and fix bugs in it",
-                            },
-                            {"role": "user", "content": prompt},
-                        ],
-                        max_tokens=1024,
-                    )
-                    return response.choices[0].message.content
+        parts = [
+            message[i : i + MAX_DISCORD_MESSAGE_LEN]
+            for i in range(0, len(message), MAX_DISCORD_MESSAGE_LEN)
+        ]
+        for part in parts:
+            await ctx.send(part)
 
-                response = generate(request)
-                # Split the response if it's longer than 2000 characters
-                if len(response) > 2000:
-                    parts = [response[i:i+2000] for i in range(0, len(response), 2000)]
-                    for part in parts:
-                        await ctx.send(part)
-                else:
-                    await ctx.send(response)
-
-            except Exception as e:
-                logging.error(e)
-                print(e)
-
-    @commands.command(
-            help="Ask the bot any question"
-    )
-    async def ask(self, ctx: commands.Context, *, arg: str):
-        request = f"{arg}"
-
-        try:
-
-            def generate(prompt):
-                response = self.aiclient.chat.completions.create(
-                    model="gpt-5-nano",
-                    messages=[{"role": "user", "content": prompt}],
-                    max_tokens=1024,
-                )
-                return response.choices[0].message.content
-
-            response = generate(request)
-
-            # Split the response if it's longer than 2000 characters
-            if len(response) > 2000:
-                parts = [response[i:i+2000] for i in range(0, len(response), 2000)]
-                for part in parts:
-                    await ctx.send(part)
-            else:
-                await ctx.send(response)
-
-
-        except Exception as e:
-            logging.error(e)
-            print(e)
-
-    @commands.command(
-            help="Ask the bot to generate a roast"
-    )
-    async def roast(self, ctx: commands.Context, *, arg: str):
-        request = f"Roast {arg}"
-
-        try:
-
-            def generate_roast(prompt):
-                response = self.aiclient.chat.completions.create(
-                    model="gpt-5-nano",
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": "You are an AI that roasts people",
-                        },
-                        {"role": "user", "content": prompt},
-                    ],
-                    max_tokens=256,
-                )
-                return response.choices[0].message.content
-
-            response = generate_roast(request)
-            await ctx.send(response)
-
-        except Exception as e:
-            logging.error(e)
-            print(e)
-
-    @commands.command(
-            help="Joins the voice chat to deliver generated roast"
-    )
-    async def vcroast(self, ctx: commands.Context, *, arg: str):
-        request = f"Roast {arg}"
-        logging.info(request)
-
-        def text_to_mp3(text: str):
-           
-            model_file = "tts_voices/model.onnx"
-            model_config = "tts_voices/model.onnx.json"
-
-            # Check if both files exist
-            if os.path.exists(model_file) and os.path.exists(model_config):
-                os.system(f"echo \"{text}\" | piper --model {model_file} --output_file speech.wav")
-                logging.info("Speech generation started.")
-            else:
-                logging.error(f"Required files not found: {model_file} or {model_config}")
-
-        def generate_roast(prompt):
+    async def _generate_chat_completion(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        model: str,
+        max_completion_tokens: int,
+    ) -> str:
+        # OpenAI call is synchronous in this SDK usage; offload it to a thread.
+        def _generate() -> str:
             response = self.aiclient.chat.completions.create(
-                model="gpt-5-nano",
-                messages=[
+                model=model,
+                messages=messages,
+                max_completion_tokens=max_completion_tokens,
+            )
+            return response.choices[0].message.content or ""
+
+        return await asyncio.to_thread(_generate)
+
+    @commands.command(help="Debugs any given code")
+    async def debug(self, ctx: commands.Context, *, arg: str):
+        try:
+            response = await self._generate_chat_completion(
+                [
                     {
                         "role": "system",
-                        "content": "You are Donald Trump. You roast people. Only speak like Donald Trump",
+                        "content": (
+                            "You will be provided with a piece of code, and your task "
+                            "is to find and fix bugs in it"
+                        ),
                     },
-                    {"role": "user", "content": prompt},
+                    {"role": "user", "content": arg},
                 ],
-                max_tokens=256,
+                model="gpt-4o-mini",
+                max_completion_tokens=1024,
             )
-            return response.choices[0].message.content
+            await self._send_long_message(ctx, response)
+        except Exception:
+            logging.exception("debug command failed")
+            await ctx.send("Something went wrong while debugging that snippet.")
+
+    @commands.command(help="Ask the bot any question")
+    async def ask(self, ctx: commands.Context, *, arg: str):
+        try:
+            response = await self._generate_chat_completion(
+                [{"role": "user", "content": arg}],
+                model="gpt-4o-mini",
+                max_completion_tokens=1024,
+            )
+            await self._send_long_message(ctx, response)
+        except Exception:
+            logging.exception("ask command failed")
+            await ctx.send("I hit an error while answering that. Please try again.")
+
+    @commands.command(help="Ask the bot to generate a roast")
+    async def roast(self, ctx: commands.Context, *, arg: str):
+        request = f"Roast {arg}"
+        try:
+            response = await self._generate_chat_completion(
+                [
+                    {"role": "system", "content": "You are an AI that roasts people"},
+                    {"role": "user", "content": request},
+                ],
+                model="gpt-4o-mini",
+                max_completion_tokens=256,
+            )
+            await self._send_long_message(ctx, response)
+        except Exception:
+            logging.exception("roast command failed")
+            await ctx.send("I couldn't generate a roast right now.")
+
+    def _text_to_wav(self, text: str) -> Path:
+        model_file = Path("tts_voices/model.onnx")
+        model_config = Path("tts_voices/model.onnx.json")
+        output_file = Path("speech.wav")
+
+        if not model_file.exists() or not model_config.exists():
+            raise FileNotFoundError(
+                f"Required files not found: {model_file} and/or {model_config}"
+            )
+
+        process = subprocess.run(
+            ["piper", "--model", str(model_file), "--output_file", str(output_file)],
+            input=text,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if process.returncode != 0:
+            raise RuntimeError(
+                f"piper exited with {process.returncode}: {process.stderr.strip()}"
+            )
+
+        return output_file
+
+    async def _connect_to_author_channel(
+        self, ctx: commands.Context
+    ) -> discord.VoiceClient | None:
+        if not ctx.author.voice or not ctx.author.voice.channel:
+            await ctx.send("You need to be in a voice channel first.")
+            return None
+
+        target_channel = ctx.author.voice.channel
+        voice_client = discord.utils.get(self.client.voice_clients, guild=ctx.guild)
 
         try:
-            response = generate_roast(request)
-            text = response
-            logging.info(text)
-            text_to_mp3(text)
+            if voice_client and voice_client.is_connected():
+                if voice_client.channel != target_channel:
+                    await voice_client.move_to(target_channel)
+                return voice_client
 
-        except Exception as e:
-            logging.error(e)
-            print(e)
-        if ctx.author.voice:
-            channel = ctx.author.voice.channel
-            vc = await channel.connect()
-            vc.play(discord.FFmpegPCMAudio("speech.wav"))
-            while vc.is_playing():
-                await asyncio.sleep(1)
-            await vc.disconnect()
-            os.remove("speech.wav")
+            return await target_channel.connect()
+        except discord.ClientException as exc:
+            logging.exception("voice connection error")
+            await ctx.send(f"I couldn't join voice: {exc}")
+            return None
+
+    @commands.command(help="Joins voice chat to deliver generated roast")
+    async def vcroast(self, ctx: commands.Context, *, arg: str):
+        request = f"Roast {arg}"
+        logging.info("vcroast request: %s", request)
+
+        try:
+            response = await self._generate_chat_completion(
+                [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are Donald Trump. You roast people. "
+                            "Only speak like Donald Trump"
+                        ),
+                    },
+                    {"role": "user", "content": request},
+                ],
+                model="gpt-4o-mini",
+                max_completion_tokens=256,
+            )
+
+            output_wav = await asyncio.to_thread(self._text_to_wav, response)
+
+            voice_client = await self._connect_to_author_channel(ctx)
+            if not voice_client:
+                return
+
+            if voice_client.is_playing():
+                voice_client.stop()
+
+            playback_finished = asyncio.Event()
+
+            def _after_playback(error: Exception | None):
+                if error:
+                    logging.error("audio playback failed: %s", error)
+                self.client.loop.call_soon_threadsafe(playback_finished.set)
+
+            voice_client.play(discord.FFmpegPCMAudio(str(output_wav)), after=_after_playback)
+            await playback_finished.wait()
+
+            await voice_client.disconnect()
+            if output_wav.exists():
+                output_wav.unlink()
+
+        except FileNotFoundError as exc:
+            logging.exception("vcroast missing tts files")
+            await ctx.send(f"TTS setup issue: {exc}")
+        except Exception:
+            logging.exception("vcroast command failed")
+            await ctx.send("I ran into an error while doing vcroast.")
 
 
 async def setup(client: commands.Bot):
-        await client.add_cog(Roast(client))
+    await client.add_cog(Roast(client))

--- a/main.py
+++ b/main.py
@@ -1,51 +1,68 @@
-import discord
-from discord.ext import commands
+import asyncio
 import json
 import logging
-import asyncio
-import os
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
 
 # Logging
 logging.basicConfig(
     filename="jazzbot.log",
-    encoding='utf-8',
-    format='%(asctime)s %(levelname)-8s %(message)s',
+    encoding="utf-8",
+    format="%(asctime)s %(levelname)-8s %(message)s",
     level=logging.INFO,
-    datefmt='%Y-%m-%d %H:%M:%S'
-    )
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
-# Config
-config_filename = 'config.json'
-logging.debug(f'Opening config file: {config_filename}')
-with open(config_filename, 'r') as cjson:
-    logging.debug('Loading JSON from config file.')
-    config = json.load(cjson)
-    logging.debug('Successfully loaded configuration.')
+
+def load_config(config_path: Path) -> dict:
+    logging.debug("Opening config file: %s", config_path)
+    with config_path.open("r", encoding="utf-8") as cjson:
+        logging.debug("Loading JSON from config file.")
+        return json.load(cjson)
+
+
+config = load_config(Path("config.json"))
 
 # Setup client
-logging.debug('Setting up Discord client/bot.')
-intents = discord.Intents.all()
+logging.debug("Setting up Discord client/bot.")
+intents = discord.Intents.default()
 intents.message_content = True
-client = commands.Bot(command_prefix=config['command_prefix'], intents=intents)
+intents.guilds = True
+intents.voice_states = True
+
+client = commands.Bot(command_prefix=config["command_prefix"], intents=intents)
 client.config = config
 
 
 @client.event
 async def on_ready():
-    logging.info(f'''We have logged in as {client.user}   
-Command prefix = \'{config['command_prefix']}\'''')
+    logging.info(
+        "We have logged in as %s | Command prefix = '%s'",
+        client.user,
+        config["command_prefix"],
+    )
+
+
+async def load_cogs() -> None:
+    cogs_dir = Path("cogs")
+    logging.debug("Registering cogs...")
+    for cog_file in cogs_dir.glob("*/cog.py"):
+        extension = f"cogs.{cog_file.parent.name}.cog"
+        try:
+            await client.load_extension(extension)
+            logging.info("Loaded cog: %s", extension)
+        except Exception:
+            logging.exception("Failed to load cog: %s", extension)
+
 
 async def main():
-    # Dynamically register cogs
-    logging.debug('Registering cogs...')
-    for folder in os.listdir('cogs'):
-        if os.path.exists(os.path.join('cogs', folder, 'cog.py')):
-            logging.debug(f'Found cog {folder}.')
-            await client.load_extension(f'cogs.{folder}.cog')
+    await load_cogs()
+    logging.debug("Starting Discord client.")
+    await client.start(config["client_token"])
 
-    logging.debug('Starting Discord client.')
-    await client.start(config['client_token'])
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     asyncio.run(main())
-    


### PR DESCRIPTION
### Motivation
- Make bot startup and configuration loading safer and more explicit to avoid encoding and silent-failure issues. 
- Reduce blocking API calls on the event loop and centralize repeated logic in the OpenAI cog to improve reliability and maintainability. 
- Fix failures joining or playing audio in voice channels by handling existing voice connections, channel moves, playback lifecycle, and TTS errors more robustly.

### Description
- Reworked `main.py` to use a UTF-8 `load_config` helper, narrowed intents to `message_content`, `guilds`, and `voice_states`, and added a `load_cogs()` loader with logging for cog load successes and failures. 
- Refactored `cogs/open_ai/cog.py` to add `_generate_chat_completion` (offloaded to `asyncio.to_thread`) and `_send_long_message` helpers, standardized model/parameter usage to `gpt-4o-mini` with `max_completion_tokens`, and removed duplicated request/response logic. 
- Replaced unsafe shell TTS invocation with `subprocess.run` in a `_text_to_wav` helper that validates model files and surfaces errors clearly. 
- Hardened voice handling with `_connect_to_author_channel` that reuses or moves existing `VoiceClient`, and updated `vcroast` to play audio with an `after` callback wired to an `asyncio.Event` for reliable playback completion and cleanup (disconnect + remove file).
- Files modified: `main.py`, `cogs/open_ai/cog.py`.

### Testing
- Ran `python -m compileall main.py cogs/open_ai/cog.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4cdb9f240832baa0a2ad543214d50)